### PR TITLE
dp-77

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -28,7 +28,7 @@ p {
   font-weight: 400;
   line-height: 20px;
   text-align: left;
-  color: #FFFFFFCC;
+  color: rgba(255, 255, 255, 0.80);
 }
 
 pre {


### PR DESCRIPTION
chore: "Section Empowering Data Ownership: Opacity Paragraph Missing":
Not missed, but changed HEX value to RGBA, maybe rendering issue.